### PR TITLE
WIP: Demonstrate the use of widgets with a basic explorer

### DIFF
--- a/pypowsybl_jupyter/__init__.py
+++ b/pypowsybl_jupyter/__init__.py
@@ -4,7 +4,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from .svg import SvgWidget, display_svg
+from .explorer import network_explorer
 from ._version import __version__, version_info
+
 
 def _jupyter_labextension_paths():
     """Called by Jupyter Lab Server to detect if it is a valid labextension and

--- a/pypowsybl_jupyter/explorer.py
+++ b/pypowsybl_jupyter/explorer.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022, RTE (http://www.rte-france.com)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from IPython.display import display
+from pypowsybl.network import Network
+from pypowsybl_jupyter.svg import display_svg
+
+import ipywidgets as widgets
+
+
+def network_explorer(network: Network):
+    """
+    Creates a basic explorer widget for this network.
+    """
+
+    vl_input = widgets.Text(
+        value='',
+        placeholder='Voltage level ID',
+        description='Voltage level:',
+        disabled=False,
+        continuous_update=True
+    )
+
+    found = widgets.SelectMultiple(
+        options=[],
+        value=[],
+        rows=10,
+        description='Found',
+        disabled=False
+    )
+
+    def on_text_changed(d):
+        vls = network.get_voltage_levels(attributes=[])
+        vls = vls[vls.index.str.startswith(d['new'])]
+        found.options = vls.index
+
+    vl_input.observe(on_text_changed, names='value')
+
+    button = widgets.Button(description="Display voltage level")
+    diagram_panel = widgets.Output()
+
+    def on_click(_):
+        with diagram_panel:
+            diagram_panel.clear_output()
+            display(display_svg(network.get_single_line_diagram(found.value[0])))
+
+    button.on_click(on_click)
+    left_panel = widgets.VBox([vl_input, found, button])
+    return widgets.HBox([left_panel, diagram_panel])


### PR DESCRIPTION
Signed-off-by: Sylvain Leclerc <sylvain.leclerc@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Feature / experimentation

**What is the new behavior (if this is a feature change)?**

Provides a `network_explorer` to display basic widgets to search voltage levels in the network and display it.
