### PR TITLE
fixes SLD's VL navigation when the filter is active

### DIFF
--- a/src/pypowsybl_jupyter/networkexplorer.py
+++ b/src/pypowsybl_jupyter/networkexplorer.py
@@ -55,8 +55,13 @@ def network_explorer(network: Network, vl_id : str = None, depth: int = 0, high_
 
     def go_to_vl(event: any):
         nonlocal selected_vl
-        selected_vl= str(event.clicked_nextvl)
-        found.value=selected_vl
+        arrow_vl= str(event.clicked_nextvl)
+        vl_filtered_list=list(found.options)
+        if arrow_vl not in vl_filtered_list:
+            vl_filtered_list.append(arrow_vl)
+            found.options=vl_filtered_list
+        selected_vl=arrow_vl    
+        found.value=arrow_vl	
 
     def toggle_switch(event: any):
         idswitch = event.clicked_switch.get('id')
@@ -106,12 +111,12 @@ def network_explorer(network: Network, vl_id : str = None, depth: int = 0, high_
     )
     
     def on_text_changed(d):
-        nonlocal selected_vl
-        found.options = vls[vls.index.str.contains(d['new'], regex=False)].index
-        if len(found.options) > 0:
-            selected_vl=d['new']
+        nonlocal found
+        if d['new'] != '':
+            found.options = vls[vls.index.str.contains(d['new'], regex=False)].index
         else:
-            selected_vl=None   
+            found.options=list(vls.index)
+            found.value=selected_vl
 
     vl_input.observe(on_text_changed, names='value')
     


### PR DESCRIPTION
…D, when the VL filter is active

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->

network explorer, SLD tab: 
- Clicking on an arrow that leads to a VL that is not in the list of filtered VLs does not display the new VL.
- Also, when the currently displayed VL is not in the list of filtered VLs, clicking on a switch does not change the switch status.

**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
