### PR TITLE
changes map widget's default initial zoom

### DIFF
--- a/js/networkmapwidget.jsx
+++ b/js/networkmapwidget.jsx
@@ -23,7 +23,7 @@ import {
 import { Box } from '@mui/system';
 import LinearProgress from '@mui/material/LinearProgress';
 
-const INITIAL_ZOOM = 9;
+const INITIAL_ZOOM = 0;
 const LABELS_ZOOM_THRESHOLD = 9;
 const ARROWS_ZOOM_THRESHOLD = 7;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

feature

**What is the current behavior?**
<!-- You can also link to an open issue here -->

When there is no geo data, the map widget's map is centered and zoomed to an odd position.

**What is the new behavior (if this is a feature change)?**

Changes the widget's initial zoom default setting so that, when there is no geo data, the entire world map is displayed.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
