### PR TITLE
fixes default NAD parameters in the explorer widget

### DIFF
--- a/src/pypowsybl_jupyter/networkexplorer.py
+++ b/src/pypowsybl_jupyter/networkexplorer.py
@@ -53,12 +53,12 @@ def network_explorer(network: Network, vl_id : str = None, use_name:bool = True,
 
     npars = nad_parameters if nad_parameters is not None else NadParameters(edge_name_displayed=False,
         id_displayed=not use_name,
-        edge_info_along_edge=False,
+        edge_info_along_edge=True,
         power_value_precision=1,
         angle_value_precision=0,
         current_value_precision=1,
         voltage_value_precision=0,
-        bus_legend=False,
+        bus_legend=True,
         substation_description_displayed=True)
     
     spars=sld_parameters if sld_parameters is not None else SldParameters(use_name=use_name, nodes_infos=True)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

sets the network explorer's default NAD parameters, to have infos displayed along the edges, and buses legends


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
