### PR TITLE
fixes selection on NAD's non-VL nodes

### DIFF
--- a/src/pypowsybl_jupyter/networkexplorer.py
+++ b/src/pypowsybl_jupyter/networkexplorer.py
@@ -103,7 +103,8 @@ def network_explorer(network: Network, vl_id : str = None, use_name:bool = True,
 
     def go_to_vl_from_nad(event: any):
         vl_id= str(event.selected_node['equipment_id'])
-        select_vl_and_activate_sld_tab(vl_id)
+        if sel_ctx.is_in_vls(vl_id):
+            select_vl_and_activate_sld_tab(vl_id)
 
     def compute_sld_data(el):
         if el is not None:

--- a/src/pypowsybl_jupyter/selectcontext.py
+++ b/src/pypowsybl_jupyter/selectcontext.py
@@ -67,3 +67,6 @@ class SelectContext:
 
     def get_history_as_list(self):
         return [(item[self.display_attribute], item['id']) for item in self.history]
+    
+    def is_in_vls(self, id):
+        return id in self.vls.index


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->

no

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->

explorer's NAD tab: restricts the 'selection' (i.e., shift + right click) on  VL nodes only. Filters out other nodes types (e.g., dangling lines' boundary nodes).


**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
