### PR TITLE
Remove obsolete style in networkmapwidget.jsx

### DIFF
--- a/js/networkmapwidget.jsx
+++ b/js/networkmapwidget.jsx
@@ -22,12 +22,12 @@ import NominalVoltageFilter from './nominal-voltage-filter';
 import './networkmapwidget.css';
 
 import {
+    Box,
     createTheme,
+    LinearProgress,
     ThemeProvider,
     StyledEngineProvider,
-} from '@mui/material/styles';
-import { Box } from '@mui/system';
-import LinearProgress from '@mui/material/LinearProgress';
+} from '@mui/material';
 
 const INITIAL_ZOOM = 0;
 const LABELS_ZOOM_THRESHOLD = 9;
@@ -65,8 +65,6 @@ const darkTheme = createTheme({
     selectedRow: {
         background: '#545C5B',
     },
-    mapboxStyle: 'mapbox://styles/mapbox/dark-v9',
-    aggrid: 'ag-theme-alpine-dark',
 });
 
 const lightTheme = createTheme({
@@ -84,8 +82,6 @@ const lightTheme = createTheme({
     selectedRow: {
         background: '#8E9C9B',
     },
-    mapboxStyle: 'mapbox://styles/mapbox/light-v9',
-    aggrid: 'ag-theme-alpine',
 });
 
 class WidgetMapEquipments extends MapEquipments {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~Docs have been added / updated (for bug fixes / features)~
- [x] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Remove obsolete style from the example file `js/networkmapwidget.jsx`.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Define styles not used be the library `@powsybl/network-viewer`.


**What is the new behavior (if this is a feature change)?**
No define it anymore.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

~**If yes, please check if the following requirements are fulfilled**~
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] ~The *Breaking Change* or *Deprecated* label has been added~
- [ ] ~The migration steps are described in the following section~

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Nothing.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
The `mapboxStyle` theme variable has been replaced by the properties [`mapTheme`](https://github.com/powsybl/powsybl-network-viewer/blob/3034dd615e853bff8d2402817ef483b6c104054a/src/components/network-map-viewer/network/network-map.tsx#L157) and [`mapLibrary`](https://github.com/powsybl/powsybl-network-viewer/blob/3034dd615e853bff8d2402817ef483b6c104054a/src/components/network-map-viewer/network/network-map.tsx#L156) of `NetworkMap` component](https://github.com/powsybl/powsybl-network-viewer/blob/3034dd615e853bff8d2402817ef483b6c104054a/src/components/network-map-viewer/network/network-map.tsx#L157).  
The `aggrid` property is a variable from `@gridsuite/commons-ui`, probably a copy-paste error.
